### PR TITLE
Fixed arrows Alignment in FAQ's (#117)

### DIFF
--- a/src/app/(routes)/faqs/page.jsx
+++ b/src/app/(routes)/faqs/page.jsx
@@ -1,6 +1,6 @@
 'use client';
 import React, { useState } from 'react';
-import { MdOutlineArrowDropDown } from 'react-icons/md';
+import { MdOutlineArrowDropDown } from 'react-icons/md'
 import {
   Accordion,
   AccordionItem,
@@ -47,7 +47,7 @@ export default function Page() {
                             : setClassName('collapsed')
                         }
                       </AccordionItemState>
-                      <div className=" flex items-center justify-around w-full p-2">
+                      <div className=" flex items-center justify-between w-full pt-2 pb-2 pl-8 pr-8">
                         <div className="flex justify-center items-center flex-wrap  p-2 bg-gray-800 rounded-lg">
                           {item.icon}
                         </div>


### PR DESCRIPTION
I fixed the arrows alignment it is happening because of the second content is is greater than the other that's why the arrow in the second accordion has its wrong position .
closes: #117 
![Screenshot 2024-05-18 233902](https://github.com/Sayak-Bhunia/mystory/assets/118350936/84239c72-7c76-437e-aea0-76888fc9e5db)
